### PR TITLE
Add inverted toggle to Camera Offset Borders.

### DIFF
--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -618,6 +618,7 @@ placements.triggers.MaxHelpingHand/CameraOffsetBorder.tooltips.bottomCenter=Whet
 placements.triggers.MaxHelpingHand/CameraOffsetBorder.tooltips.bottomRight=Whether this border should have an effect when the player is on the bottom-right of it.
 placements.triggers.MaxHelpingHand/CameraOffsetBorder.tooltips.inside=Whether this border should have an effect when the player is inside it.
 placements.triggers.MaxHelpingHand/CameraOffsetBorder.tooltips.flag=The flag that must be activated for this border to have an effect. Can be left empty to make activation depend on player position only.
+placements.triggers.MaxHelpingHand/CameraOffsetBorder.tooltips.inverted=If checked, this border will be disabled when the flag is active.\nIf unchecked, this border will be enabled when the flag is active.
 
 # Disable Ice Physics Trigger
 placements.triggers.MaxHelpingHand/DisableIcePhysicsTrigger.tooltips.disableIcePhysics=Check to disable ice physics when entering the trigger. Uncheck to enable them again.

--- a/Ahorn/triggers/maxHelpingHandCameraOffsetBorder.jl
+++ b/Ahorn/triggers/maxHelpingHandCameraOffsetBorder.jl
@@ -4,7 +4,7 @@ using ..Ahorn, Maple
 
 @mapdef Trigger "MaxHelpingHand/CameraOffsetBorder" CameraOffsetBorder(x::Integer, y::Integer, width::Integer=Maple.defaultTriggerWidth, height::Integer=Maple.defaultTriggerHeight,
     topLeft::Bool=true, topCenter::Bool=true, topRight::Bool=true, centerLeft::Bool=true, centerRight::Bool=true, bottomLeft::Bool=true, bottomCenter::Bool=true, bottomRight::Bool=true,
-    flag::String="", inside::Bool=false)
+    flag::String="", inside::Bool=false, inverted::Bool=false)
 
 const placements = Ahorn.PlacementDict(
     "Camera Offset Border (max480's Helping Hand)" => Ahorn.EntityPlacement(
@@ -13,6 +13,6 @@ const placements = Ahorn.PlacementDict(
     )
 )
 
-Ahorn.editingOrder(entity::CameraOffsetBorder) = String["x", "y", "width", "height", "topLeft", "topCenter", "topRight", "centerLeft", "centerRight", "bottomLeft", "bottomCenter", "bottomRight", "flag", "inside"]
+Ahorn.editingOrder(entity::CameraOffsetBorder) = String["x", "y", "width", "height", "topLeft", "topCenter", "topRight", "centerLeft", "centerRight", "bottomLeft", "bottomCenter", "bottomRight", "flag", "inverted", "inside"]
 
 end

--- a/Triggers/CameraOffsetBorder.cs
+++ b/Triggers/CameraOffsetBorder.cs
@@ -12,7 +12,7 @@ namespace Celeste.Mod.MaxHelpingHand.Triggers {
     [CustomEntity("MaxHelpingHand/CameraOffsetBorder")]
     [Tracked]
     public class CameraOffsetBorder : Trigger {
-        private readonly bool topLeft, topCenter, topRight, centerLeft, centerRight, bottomLeft, bottomCenter, bottomRight, inside;
+        private readonly bool topLeft, topCenter, topRight, centerLeft, centerRight, bottomLeft, bottomCenter, bottomRight, inside, inverted;
         private readonly string flag;
 
         public CameraOffsetBorder(EntityData data, Vector2 offset) : base(data, offset) {
@@ -27,6 +27,7 @@ namespace Celeste.Mod.MaxHelpingHand.Triggers {
             inside = data.Bool("inside");
 
             flag = data.Attr("flag");
+            inverted = data.Bool("inverted");
             AddTag(Tags.TransitionUpdate);
         }
 
@@ -40,8 +41,11 @@ namespace Celeste.Mod.MaxHelpingHand.Triggers {
 
             Player player = Scene.Tracker.GetEntity<Player>();
             if (player != null) {
-                if (!string.IsNullOrEmpty(flag) && !(Scene as Level).Session.GetFlag(flag)) {
-                    // trigger is flag-toggled, but the associated flag is disabled.
+                if (!string.IsNullOrEmpty(flag) && !(Scene as Level).Session.GetFlag(flag) && !inverted) {
+                    // trigger is flag-toggled, but the associated flag is disabled and the trigger has "inverted" disabled.
+                    Collidable = false;
+                } else if (!string.IsNullOrEmpty(flag) && (Scene as Level).Session.GetFlag(flag) && inverted) {
+                    // trigger is flag-toggled, but the associated flag is enabled and the trigger has "inverted" enabled.
                     Collidable = false;
                 } else {
                     bool top = player.Bottom <= Top;


### PR DESCRIPTION
Adds an `inverted` toggle to camera offset borders which makes it so, when checked, the border disables itself when the associated flag is active, rather than enable itself when the associated flag is active.