### PR TITLE
Add 'Attach Static Movers' toggle to 'CustomizableCrumblePlatform'

### DIFF
--- a/Ahorn/entities/maxHelpingHandCustomizableCrumblePlatform.jl
+++ b/Ahorn/entities/maxHelpingHandCustomizableCrumblePlatform.jl
@@ -4,7 +4,8 @@ using ..Ahorn, Maple
 
 @mapdef Entity "MaxHelpingHand/CustomizableCrumblePlatform" CustomizableCrumblePlatform(x::Integer, y::Integer, width::Integer=Maple.defaultBlockWidth,
     texture::String="default", oneUse::Bool=false, respawnDelay::Number=2.0, grouped::Bool=false, minCrumbleDurationOnTop::Number=0.2,
-    maxCrumbleDurationOnTop::Number=0.6, crumbleDurationOnSide::Number=1.0, outlineTexture::String="objects/crumbleBlock/outline", onlyEmitSoundForPlayer::Bool=false, fadeOutTint::String="808080")
+    maxCrumbleDurationOnTop::Number=0.6, crumbleDurationOnSide::Number=1.0, outlineTexture::String="objects/crumbleBlock/outline", onlyEmitSoundForPlayer::Bool=false, fadeOutTint::String="808080",
+    attachStaticMovers::Bool=false)
 
 const placements = Ahorn.PlacementDict(
     "Crumble Blocks ($(uppercasefirst(texture)), Customizable)\n(max480's Helping Hand)" => Ahorn.EntityPlacement(

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -84,6 +84,7 @@ placements.entities.MaxHelpingHand/CustomizableCrumblePlatform.tooltips.crumbleD
 placements.entities.MaxHelpingHand/CustomizableCrumblePlatform.tooltips.outlineTexture=The path to the outline texture (that appears while the platform is respawning), in Graphics/Atlases/Gameplay.\nTo use the texture at Graphics/Atlases/Gameplay/somefolder/texturename.png in your mod, write "somefolder/texturename" here.\nYou'll find the vanilla texture in the graphics dump, in Graphics/Atlases/Gameplay/objects/crumbleBlock/outline.png.
 placements.entities.MaxHelpingHand/CustomizableCrumblePlatform.tooltips.onlyEmitSoundForPlayer=If checked, the crumble block will only emit sound when triggered by the player (not when triggered by another crumble block in the group).
 placements.entities.MaxHelpingHand/CustomizableCrumblePlatform.tooltips.fadeOutTint=The tint/color to use while the crumble block falls apart.
+placements.entities.MaxHelpingHand/CustomizableCrumblePlatform.tooltips.attachStaticMovers=If checked, any static movers (spikes, springs, etc.) attached to the platform will crumble along with it when it crumbles.
 
 # Upside Down Jump Thru
 placements.entities.MaxHelpingHand/UpsideDownJumpThru.tooltips.texture=Changes the appearance of the platform. Should be in the same format as vanilla for static jumpthrus, and a 8x8 image for animated ones.

--- a/Entities/CustomizableCrumblePlatform.cs
+++ b/Entities/CustomizableCrumblePlatform.cs
@@ -52,6 +52,7 @@ namespace Celeste.Mod.MaxHelpingHand.Entities {
         private bool grouped;
         private bool onlyEmitSoundForPlayer;
         private Color fadeOutTint;
+        private bool attachStaticMovers;
 
         private HashSet<CustomizableCrumblePlatform> groupedCrumblePlatforms = new HashSet<CustomizableCrumblePlatform>();
 
@@ -66,6 +67,7 @@ namespace Celeste.Mod.MaxHelpingHand.Entities {
             grouped = data.Bool("grouped", false);
             onlyEmitSoundForPlayer = data.Bool("onlyEmitSoundForPlayer", false);
             fadeOutTint = data.HexColor("fadeOutTint", Color.Gray);
+            attachStaticMovers = data.Bool("attachStaticMovers", false);
         }
 
         private static void onCrumblePlatformAdded(ILContext il) {
@@ -208,6 +210,9 @@ namespace Celeste.Mod.MaxHelpingHand.Entities {
                 outlineFader.Replace((IEnumerator) crumblePlatformOutlineFade.Invoke(this, new object[] { 1f }));
                 occluder.Visible = false;
                 Collidable = false;
+                if (attachStaticMovers) {
+                    DisableStaticMovers();
+                }
                 float delay = 0.05f;
                 for (int m = 0; m < 4; m++) {
                     for (int i = 0; i < images.Count; i++) {
@@ -236,6 +241,9 @@ namespace Celeste.Mod.MaxHelpingHand.Entities {
                 outlineFader.Replace((IEnumerator) crumblePlatformOutlineFade.Invoke(this, new object[] { 0f }));
                 occluder.Visible = true;
                 Collidable = true;
+                if (attachStaticMovers) {
+                    EnableStaticMovers();
+                }
                 for (int m = 0; m < 4; m++) {
                     for (int i = 0; i < images.Count; i++) {
                         if (i % 4 - m == 0) {


### PR DESCRIPTION
Adds an `attachStaticMovers` toggle to `CustomizableCrumblePlatform` which makes it so, when checked, any static movers (spikes, springs, etc.) touching the crumble block will also disappear along with the block when it crumbles.

At the moment the attached static movers vanish quite abruptly, however to my knowledge there is nothing that can be done about this.