### PR TITLE
Add 'Set Custom Inventory' Trigger

### DIFF
--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -949,3 +949,9 @@ placements.triggers.MaxHelpingHand/ExtendedDialogCutsceneTrigger.tooltips.dialog
 placements.triggers.MaxHelpingHand/ExtendedDialogCutsceneTrigger.tooltips.endLevel=Whether finishing the dialog triggers the level to end.
 placements.triggers.MaxHelpingHand/ExtendedDialogCutsceneTrigger.tooltips.deathCount=Determines the exact amount of deaths required to activate dialog trigger. Will always trigger if set to -1.
 placements.triggers.MaxHelpingHand/ExtendedDialogCutsceneTrigger.tooltips.font=The name of the font to use for the dialogue.\nShould match the name of the font file you sent to the Font Generator (without extension).
+
+# Set Custom Inventory Trigger
+placements.triggers.MaxHelpingHand/SetCustomInventoryTrigger.tooltips.dashes=The amount of dashes the player gets when their dash gets refilled.
+placements.triggers.MaxHelpingHand/SetCustomInventoryTrigger.tooltips.dream_dash=Whether the player can dash through dream blocks or not.
+placements.triggers.MaxHelpingHand/SetCustomInventoryTrigger.tooltips.backpack=Whether the player has a backpack or not.
+placements.triggers.MaxHelpingHand/SetCustomInventoryTrigger.tooltips.ground_refills=Whether the player gets a refill upon touching the ground.

--- a/Ahorn/triggers/maxHelpingHandSetCustomInventoryTrigger.jl
+++ b/Ahorn/triggers/maxHelpingHandSetCustomInventoryTrigger.jl
@@ -1,0 +1,15 @@
+module MaxHelpingHandSetCustomInventoryTrigger
+
+using ..Ahorn, Maple
+
+@mapdef Trigger "MaxHelpingHand/SetCustomInventoryTrigger" SetCustomInventoryTrigger(x::Integer, y::Integer, width::Integer=Maple.defaultTriggerWidth, height::Integer=Maple.defaultTriggerHeight,
+    dashes::Integer=1, backpack::Bool=true, dreamDash::Bool=false, groundRefills::Bool=true)
+
+const placements = Ahorn.PlacementDict(
+    "Set Custom Inventory Trigger (max480's Helping Hand)" => Ahorn.EntityPlacement(
+        SetCustomInventoryTrigger,
+        "rectangle"
+    )
+)
+
+end

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -1141,3 +1141,10 @@ triggers.MaxHelpingHand/ExtendedDialogCutsceneTrigger.attributes.description.dia
 triggers.MaxHelpingHand/ExtendedDialogCutsceneTrigger.attributes.description.endLevel=Whether finishing the dialog triggers the level to end.
 triggers.MaxHelpingHand/ExtendedDialogCutsceneTrigger.attributes.description.deathCount=Determines the exact amount of deaths required to activate dialog trigger. Will always trigger if set to -1.
 triggers.MaxHelpingHand/ExtendedDialogCutsceneTrigger.attributes.description.font=The name of the font to use for the dialogue.\nShould match the name of the font file you sent to the Font Generator (without extension).
+
+# Set Custom Inventory Trigger
+triggers.MaxHelpingHand/SetCustomInventoryTrigger.placements.name.normal=Set Custom Inventory Trigger
+triggers.MaxHelpingHand/SetCustomInventoryTrigger.attributes.description.dashes=The amount of dashes the player gets when their dash gets refilled.
+triggers.MaxHelpingHand/SetCustomInventoryTrigger.attributes.description.dream_dash=Whether the player can dash through dream blocks or not.
+triggers.MaxHelpingHand/SetCustomInventoryTrigger.attributes.description.backpack=Whether the player has a backpack or not.
+triggers.MaxHelpingHand/SetCustomInventoryTrigger.attributes.description.ground_refills=Whether the player gets a refill upon touching the ground.

--- a/Loenn/triggers/setCustomInventoryTrigger.lua
+++ b/Loenn/triggers/setCustomInventoryTrigger.lua
@@ -9,8 +9,8 @@ trigger.placements = {
             height = 8,
             dashes = 1,
             backpack = true,
-            dream_dash = false,
-            ground_refills = true,
+            dreamDash = false,
+            groundRefills = true,
         },
     },
 }

--- a/Loenn/triggers/setCustomInventoryTrigger.lua
+++ b/Loenn/triggers/setCustomInventoryTrigger.lua
@@ -1,0 +1,23 @@
+local trigger = {}
+
+trigger.name = "MaxHelpingHand/SetCustomInventoryTrigger"
+trigger.placements = {
+    {
+        name = "normal",
+        data = {
+            width = 8,
+            height = 8,
+            dashes = 1,
+            backpack = true,
+            dream_dash = false,
+            ground_refills = true,
+        },
+    },
+}
+trigger.fieldInformation = {
+    dashes = {
+        fieldType = "integer",
+    },
+}
+
+return trigger

--- a/Triggers/SetCustomInventoryTrigger.cs
+++ b/Triggers/SetCustomInventoryTrigger.cs
@@ -5,19 +5,19 @@ namespace Celeste.Mod.MaxHelpingHand.Triggers {
     [CustomEntity("MaxHelpingHand/SetCustomInventoryTrigger")]
     public class SetCustomInventoryTrigger : Trigger {
         private int dashes = 1;
-        private bool dream_dash = false;
-        private bool ground_refills = true;
+        private bool dreamDash = false;
+        private bool groundRefills = true;
         private bool backpack = true;
 
         public SetCustomInventoryTrigger(EntityData data, Vector2 offset) : base(data, offset) {
             dashes = (int)data.Values["dashes"];
-            dream_dash = (bool)data.Values["dream_dash"];
-            ground_refills = (bool)data.Values["ground_refills"];
+            dreamDash = (bool)data.Values["dreamDash"];
+            groundRefills = (bool)data.Values["groundRefills"];
             backpack = (bool)data.Values["backpack"];
         }
 
         public override void OnEnter(Player player) {
-            (base.Scene as Level).Session.Inventory = new PlayerInventory(dashes, dream_dash, backpack, !ground_refills);
+            (base.Scene as Level).Session.Inventory = new PlayerInventory(dashes, dreamDash, backpack, !groundRefills);
         }
     }
 }

--- a/Triggers/SetCustomInventoryTrigger.cs
+++ b/Triggers/SetCustomInventoryTrigger.cs
@@ -1,0 +1,23 @@
+﻿using Celeste.Mod.Entities;
+using Microsoft.Xna.Framework;
+
+namespace Celeste.Mod.MaxHelpingHand.Triggers {
+    [CustomEntity("MaxHelpingHand/SetCustomInventoryTrigger")]
+    public class SetCustomInventoryTrigger : Trigger {
+        private int dashes = 1;
+        private bool dream_dash = false;
+        private bool ground_refills = true;
+        private bool backpack = true;
+
+        public SetCustomInventoryTrigger(EntityData data, Vector2 offset) : base(data, offset) {
+            dashes = (int)data.Values["dashes"];
+            dream_dash = (bool)data.Values["dream_dash"];
+            ground_refills = (bool)data.Values["ground_refills"];
+            backpack = (bool)data.Values["backpack"];
+        }
+
+        public override void OnEnter(Player player) {
+            (base.Scene as Level).Session.Inventory = new PlayerInventory(dashes, dream_dash, backpack, !ground_refills);
+        }
+    }
+}

--- a/Triggers/SetCustomInventoryTrigger.cs
+++ b/Triggers/SetCustomInventoryTrigger.cs
@@ -18,6 +18,7 @@ namespace Celeste.Mod.MaxHelpingHand.Triggers {
 
         public override void OnEnter(Player player) {
             (base.Scene as Level).Session.Inventory = new PlayerInventory(dashes, dreamDash, backpack, !groundRefills);
+            player.ResetSprite(backpack ? PlayerSpriteMode.Madeline : PlayerSpriteMode.MadelineNoBackpack);
         }
     }
 }


### PR DESCRIPTION
Adds a trigger that allows you to customize the player's inventory on a per-property basis instead of using presets like the Everest trigger.
![image](https://user-images.githubusercontent.com/58695417/214885729-1adde617-195e-4295-ada1-cc574e84bb7c.png)


I didn't feel like creating my own helper for this one feature, So I just decided to contribute it to MaxHelpingHand.
This trigger currently has 0 problems I have yet to resolve:

- ~~It has no Ahorn support, I couldn't find the documentation for it. And a guy on the Celeste Discord said that helpers usually don't add Ahorn support anymore.~~ I have added that. I'm never doing that again that was a horrible experience.

- ~~For some reason changing `backpack` property doesnt visually change whether the player has a backpack or not. It changes the property internally (I checked using `Console.WriteLine` statements) but it doesn't show on the player for some reason.~~ Fixed!