### PR TITLE
Implement rotation for customizable Strawberries, Crystal Hearts and Refills

### DIFF
--- a/Entities/CustomizableRefill.cs
+++ b/Entities/CustomizableRefill.cs
@@ -1,13 +1,35 @@
 ﻿using Celeste.Mod.Entities;
 using Microsoft.Xna.Framework;
 using Monocle;
-using MonoMod.Utils;
 using System;
-using System.Reflection;
 
 namespace Celeste.Mod.MaxHelpingHand.Entities {
     [CustomEntity("MaxHelpingHand/CustomizableRefill")]
     public class CustomizableRefill : Refill {
+        internal static void Load() {
+            On.Celeste.Refill.UpdateY += modUpdateY;
+        }
+
+        internal static void Unload() {
+            On.Celeste.Refill.UpdateY -= modUpdateY;
+        }
+
+        private static void modUpdateY(On.Celeste.Refill.orig_UpdateY orig, Refill self) {
+            if (self is CustomizableRefill refill)
+                refill.RotatedUpdateY();
+            else
+                orig(self);
+        }
+
+        private float _rotationDegrees;
+        public float rotationDegrees {
+            get => _rotationDegrees;
+            set {
+                _rotationDegrees = value;
+                outline.Rotation = sprite.Rotation = flash.Rotation = _rotationDegrees * Calc.DegToRad;
+            }
+        }
+
         public CustomizableRefill(EntityData data, Vector2 offset) : base(data, offset) {
             float respawnTime = data.Float("respawnTime", 2.5f);
 
@@ -55,13 +77,23 @@ namespace Celeste.Mod.MaxHelpingHand.Entities {
                 };
             }
 
+            // we can set the property right here, as the outline and sprites are non-null after the constructor
+            rotationDegrees = data.Float("rotation");
+
             if (!data.Bool("wave", true)) {
                 // freeze the sine wave and remove it so that it stops updating.
                 SineWave sine = Get<SineWave>();
                 Remove(sine);
                 sine.Counter = 0f;
-                UpdateY();
+                RotatedUpdateY();
             }
         }
+
+        private void RotatedUpdateY() {
+            sprite.Position = flash.Position = bloom.Position = GetRotationVector(sine.Value * 2);
+        }
+
+        public Vector2 GetRotationVector(float length)
+            => Calc.AngleToVector(Calc.Up + rotationDegrees * Calc.DegToRad, length);
     }
 }

--- a/Entities/ReskinnableCrystalHeart.cs
+++ b/Entities/ReskinnableCrystalHeart.cs
@@ -5,10 +5,10 @@ using Mono.Cecil.Cil;
 using Monocle;
 using MonoMod.Cil;
 using MonoMod.RuntimeDetour;
-using MonoMod.Utils;
 using System;
 using System.Linq;
 using System.Reflection;
+using Celeste.Mod.Helpers;
 
 namespace Celeste.Mod.MaxHelpingHand.Entities {
     [CustomEntity("MaxHelpingHand/ReskinnableCrystalHeart")]
@@ -19,11 +19,13 @@ namespace Celeste.Mod.MaxHelpingHand.Entities {
         public static void Load() {
             IL.Celeste.HeartGem.Awake += onHeartGemAwake;
             On.Celeste.HeartGem.Collect += onHeartGemCollect;
+            IL.Celeste.HeartGem.Update += modHeartGemUpdate;
         }
 
         public static void Unload() {
             IL.Celeste.HeartGem.Awake -= onHeartGemAwake;
             On.Celeste.HeartGem.Collect -= onHeartGemCollect;
+            IL.Celeste.HeartGem.Update -= modHeartGemUpdate;
 
             altSidesHelperHook?.Dispose();
             altSidesHelperHook = null;
@@ -44,6 +46,16 @@ namespace Celeste.Mod.MaxHelpingHand.Entities {
         private readonly bool flagInverted;
         private readonly bool disableGhostSprite;
 
+        private float _rotationDegrees;
+        public float rotationDegrees {
+            get => _rotationDegrees;
+            set {
+                _rotationDegrees = value;
+                if (sprite is not null)
+                    sprite.Rotation = _rotationDegrees * Calc.DegToRad;
+            }
+        }
+
         public ReskinnableCrystalHeart(EntityData data, Vector2 offset) : base(data, offset) {
             overrideSprite = data.Attr("sprite");
             ghostSprite = data.Attr("ghostSprite");
@@ -51,6 +63,9 @@ namespace Celeste.Mod.MaxHelpingHand.Entities {
             flagOnCollect = data.Attr("flagOnCollect");
             flagInverted = data.Bool("flagInverted");
             disableGhostSprite = data.Bool("disableGhostSprite");
+
+            // need to set sprite rotation in Awake, as this is where it's set
+            _rotationDegrees = data.Float("rotation");
         }
 
         public override void Added(Scene scene) {
@@ -76,7 +91,16 @@ namespace Celeste.Mod.MaxHelpingHand.Entities {
 
                 shineParticle = particle;
             }
+
+            sprite.Rotation = _rotationDegrees * Calc.DegToRad;
         }
+
+        private void RotatedWiggle() {
+            sprite.Position = GetRotationVector(MathF.Sin(timer * 2f) * 2f) + moveWiggleDir * (moveWiggler.Value * -8f);
+        }
+
+        public Vector2 GetRotationVector(float length)
+            => Calc.AngleToVector(Calc.Up + rotationDegrees * Calc.DegToRad, length);
 
         private static void onHeartGemAwake(ILContext il) {
             ILCursor cursor = new ILCursor(il);
@@ -123,6 +147,48 @@ namespace Celeste.Mod.MaxHelpingHand.Entities {
             }
 
             orig(self, player);
+        }
+
+        private static void modHeartGemUpdate(ILContext il) {
+            ILCursor cursor = new ILCursor(il);
+
+            // we need to mess with the y oscillation of the heart.
+            // the il making up this section is veeeeeery long, so let's just match the beginning and the end.
+            // ...and Pray
+            if (!cursor.TryGotoNextBestFit(
+                MoveType.Before,
+                static instr => instr.MatchLdarg(0),
+                static instr => instr.MatchLdfld<HeartGem>("sprite"),
+                static instr => instr.MatchCall<Vector2>("get_UnitY")))
+                return;
+
+            ILLabel skipWiggle = cursor.DefineLabel();
+            int emitIndex = cursor.Index;
+
+            if (!cursor.TryGotoNextBestFit(
+                MoveType.After,
+                static instr => instr.MatchLdcR4(-8),
+                static instr => instr.MatchCall<Vector2>("op_Multiply"),
+                static instr => instr.MatchCall<Vector2>("op_Addition"),
+                static instr => instr.MatchStfld<GraphicsComponent>("Position")))
+                return;
+
+            cursor.MarkLabel(skipWiggle);
+            cursor.Index = emitIndex;
+
+            Logger.Log("MaxHelpingHand/ReskinnableCrystalHeart", $"Inserting rotated Y oscillation and branch at {cursor.Index} in IL for HeartGem.Update");
+
+            cursor.EmitLdarg0();
+            cursor.EmitDelegate(tryRotatedWiggle);
+            cursor.EmitBrtrue(skipWiggle);
+        }
+
+        private static bool tryRotatedWiggle(HeartGem self) {
+            if (self is not ReskinnableCrystalHeart heart)
+                return false;
+
+            heart.RotatedWiggle();
+            return true;
         }
 
         private static void disableAltSidesHelperReskinning(Action<EverestModule, On.Celeste.HeartGem.orig_Awake, HeartGem, Scene> orig, EverestModule self,

--- a/Entities/SecretBerry.cs
+++ b/Entities/SecretBerry.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections;
 using System.Linq;
 using System.Reflection;
+using Celeste.Mod.Helpers;
 
 namespace Celeste.Mod.MaxHelpingHand.Entities {
     [CustomEntity("MaxHelpingHand/SecretBerry")]
@@ -17,6 +18,7 @@ namespace Celeste.Mod.MaxHelpingHand.Entities {
     public class SecretBerry : Strawberry {
         private static ILHook strawberryCollectRoutineHook;
         private static ILHook strawberryCollectRoutineHook2;
+        private static ILHook strawberryOrigUpdateHook;
 
         public static void Load() {
             IL.Celeste.Strawberry.OnAnimate += replaceStrawberryStrings;
@@ -29,6 +31,7 @@ namespace Celeste.Mod.MaxHelpingHand.Entities {
 
             On.Celeste.Strawberry.CollectRoutine += onStrawberryCollect;
             On.Celeste.Strawberry.Update += onStrawberryUpdate;
+            strawberryOrigUpdateHook = new ILHook(typeof(Strawberry).GetMethod(nameof(orig_Update)), modStrawberryOrigUpdate);
 
             On.Celeste.MapData.Load += onMapDataLoad;
 
@@ -48,6 +51,8 @@ namespace Celeste.Mod.MaxHelpingHand.Entities {
 
             On.Celeste.Strawberry.CollectRoutine -= onStrawberryCollect;
             On.Celeste.Strawberry.Update -= onStrawberryUpdate;
+            strawberryOrigUpdateHook?.Dispose();
+            strawberryOrigUpdateHook = null;
 
             On.Celeste.MapData.Load -= onMapDataLoad;
 
@@ -144,6 +149,32 @@ namespace Celeste.Mod.MaxHelpingHand.Entities {
             P_GhostGlow = origGhostGlow;
         }
 
+        private static void modStrawberryOrigUpdate(ILContext il) {
+            ILCursor cursor = new ILCursor(il);
+
+            ILLabel skipWiggle = null;
+            if (!cursor.TryGotoNextBestFit(
+                MoveType.After,
+                static instr => instr.MatchLdarg0(),
+                static instr => instr.MatchCallvirt<Strawberry>("get_Winged"),
+                instr => instr.MatchBrtrue(out skipWiggle)))
+                return;
+
+            Logger.Log("MaxHelpingHand/SecretBerry", $"Inserting rotated Y oscillation and branch at {cursor.Index} in IL for Strawberry.orig_Update");
+
+            cursor.EmitLdarg0();
+            cursor.EmitDelegate(tryRotatedWiggle);
+            cursor.EmitBrtrue(skipWiggle);
+        }
+
+        private static bool tryRotatedWiggle(Strawberry self) {
+            if (self is not SecretBerry berry)
+                return false;
+
+            berry.RotatedWiggle();
+            return true;
+        }
+
         private static void onMapDataLoad(On.Celeste.MapData.orig_Load orig, MapData self) {
             orig(self);
 
@@ -193,6 +224,16 @@ namespace Celeste.Mod.MaxHelpingHand.Entities {
         private readonly string visibleIfFlag;
         private StrawberryToggler toggler;
 
+        private float _rotationDegrees;
+        public float rotationDegrees {
+            get => _rotationDegrees;
+            set {
+                _rotationDegrees = value;
+                if (sprite is not null)
+                    sprite.Rotation = rotationDegrees * Calc.DegToRad;
+            }
+        }
+
         public SecretBerry(EntityData data, Vector2 offset, EntityID gid) : base(data, offset, gid) {
             strawberrySprite = data.Attr("strawberrySprite");
             ghostberrySprite = data.Attr("ghostberrySprite");
@@ -204,6 +245,9 @@ namespace Celeste.Mod.MaxHelpingHand.Entities {
             spotlightEnabled = data.Bool("spotlightEnabled", defaultValue: true);
             moonBerrySound = data.Bool("moonBerrySound", defaultValue: false);
             visibleIfFlag = data.Attr("visibleIfFlag");
+
+            // need to set sprite rotation in Added, as this is where it's set
+            _rotationDegrees = data.Float("rotation");
 
             strawberryParticleType = new ParticleType(P_Glow) {
                 Color = Calc.HexToColor(data.Attr("particleColor1")),
@@ -218,6 +262,7 @@ namespace Celeste.Mod.MaxHelpingHand.Entities {
         public override void Added(Scene scene) {
             base.Added(scene);
 
+            sprite.Rotation = rotationDegrees * Calc.DegToRad;
             if (!string.IsNullOrEmpty(visibleIfFlag) && scene is Level level) {
                 scene.Add(toggler = new StrawberryToggler(this, visibleIfFlag, level));
             }
@@ -227,6 +272,17 @@ namespace Celeste.Mod.MaxHelpingHand.Entities {
                 Remove(Get<BloomPoint>());
             }
         }
+
+        private void RotatedWiggle() {
+            wobble += Engine.DeltaTime * 4f;
+            Vector2 rotatedWobbleVector = GetRotationVector(MathF.Sin(wobble) * 2);
+            sprite.Position = rotatedWobbleVector;
+            if (spotlightEnabled)
+                bloom.Position = light.Position = rotatedWobbleVector;
+        }
+
+        public Vector2 GetRotationVector(float length)
+            => Calc.AngleToVector(Calc.Up + rotationDegrees * Calc.DegToRad, length);
 
         // this is in a separate entity, because it can freeze the berry entirely...
         // without freezing the process that unfreezes it when the flag is set.

--- a/Loenn/entities/customizableBerry.lua
+++ b/Loenn/entities/customizableBerry.lua
@@ -4,6 +4,9 @@ strawberry.name = "MaxHelpingHand/CustomizableBerry"
 strawberry.depth = -100
 
 strawberry.texture = "collectables/strawberry/normal00"
+function strawberry.rotation(room, entity)
+    return entity.rotation and (entity.rotation / 180 * math.pi) or 0
+end
 
 strawberry.placements = {
     name = "berry",
@@ -24,11 +27,23 @@ strawberry.placements = {
         particleColor2 = "FFF4A8",
         ghostParticleColor1 = "6385FF",
         ghostParticleColor2 = "72F0FF",
+        rotation = 0,
         visibleIfFlag = ""
     }
 }
 
-strawberry.fieldOrder = {"x", "y", "strawberrySprite", "ghostberrySprite", "strawberryPulseSound", "strawberryTouchSound", "strawberryBlueTouchSound", "strawberryGetSound", "particleColor1", "particleColor2", "ghostParticleColor1", "ghostParticleColor2"}
+strawberry.fieldOrder = {
+    "x", "y",
+    "strawberrySprite", "ghostberrySprite",
+    "strawberryPulseSound", "strawberryTouchSound",
+    "strawberryBlueTouchSound", "strawberryGetSound",
+    "particleColor1", "particleColor2",
+    "ghostParticleColor1", "ghostParticleColor2",
+    "checkpointID", "order",
+    "rotation", "visibleIfFlag",
+    "moonBerrySound", "pulseEnabled", "spotlightEnabled"
+}
+
 strawberry.ignoredFields = {"_id", "_name", "countTowardsTotal"}
 
 strawberry.fieldInformation = {
@@ -49,6 +64,9 @@ strawberry.fieldInformation = {
     },
     checkpointID = {
         fieldType = "integer"
+    },
+    rotation = {
+        default = 0
     }
 }
 

--- a/Loenn/entities/customizableRefill.lua
+++ b/Loenn/entities/customizableRefill.lua
@@ -14,6 +14,7 @@ refill.placements = {
             shatterParticleColor2 = "",
             glowParticleColor1 = "",
             glowParticleColor2 = "",
+            rotation = 0,
             wave = true
         }
     },
@@ -28,14 +29,57 @@ refill.placements = {
             shatterParticleColor2 = "",
             glowParticleColor1 = "",
             glowParticleColor2 = "",
+            rotation = 0,
             wave = true
         }
+    }
+}
+
+refill.fieldOrder = {
+    "x", "y",
+    "sprite", "respawnTime",
+    "shatterParticleColor1", "shatterParticleColor2",
+    "glowParticleColor1", "glowParticleColor2",
+    "rotation", "_spacer",
+    "oneUse", "twoDash",
+    "wave"
+}
+
+refill.fieldInformation = {
+    shatterParticleColor1 = {
+        fieldType = "color",
+        allowEmpty = true
+    },
+    shatterParticleColor2 = {
+        fieldType = "color",
+        allowEmpty = true
+    },
+    glowParticleColor1 = {
+        fieldType = "color",
+        allowEmpty = true
+    },
+    glowParticleColor2 = {
+        fieldType = "color",
+        allowEmpty = true
+    },
+    rotation = {
+        default = 0
+    },
+
+    -- a hack borrowed from lönn's setting window to let us insert a spacer,
+    -- this way the menu is ordered neatly
+    _spacer = {
+        fieldType = "spacer"
     }
 }
 
 function refill.texture(room, entity)
     return entity.sprite ~= "" and "objects/MaxHelpingHand/refill/" .. entity.sprite .. "/idle00" or
         (entity.twoDash and "objects/refillTwo/idle00" or "objects/refill/idle00")
+end
+
+function refill.rotation(room, entity)
+    return entity.rotation and (entity.rotation / 180 * math.pi) or 0
 end
 
 return refill

--- a/Loenn/entities/reskinnableCrystalHeart.lua
+++ b/Loenn/entities/reskinnableCrystalHeart.lua
@@ -13,9 +13,19 @@ heart.placements = {
         ghostSprite = "",
         particleColor = "",
         flagOnCollect = "",
+        rotation = 0,
         flagInverted = false,
         disableGhostSprite = false
     }
+}
+
+heart.fieldOrder = {
+    "x", "y",
+    "fakeHeartDialog", "keepGoingDialog",
+    "sprite", "ghostSprite",
+    "particleColor", "flagOnCollect",
+    "rotation", "_spacer",
+    "disableGhostSprite", "fake", "flagInverted", "removeCameraTriggers"
 }
 
 heart.fieldInformation = {
@@ -24,6 +34,19 @@ heart.fieldInformation = {
     },
     ghostSprite = {
         options = { "", "heartgem0", "heartgem1", "heartgem2", "heartgem3" }
+    },
+    particleColor = {
+        fieldType = "color",
+        allowEmpty = true
+    },
+    rotation = {
+        default = 0
+    },
+
+    -- a hack borrowed from lönn's setting window to let us insert a spacer,
+    -- this way the menu is ordered neatly
+    _spacer = {
+        fieldType = "spacer"
     }
 }
 
@@ -38,6 +61,9 @@ function heart.texture(room, entity)
     else
         return "collectables/heartGem/0/00"
     end
+end
+function heart.rotation(room, entity)
+    return entity.rotation and (entity.rotation / 180 * math.pi) or 0
 end
 
 return heart

--- a/Loenn/entities/secretBerry.lua
+++ b/Loenn/entities/secretBerry.lua
@@ -4,6 +4,9 @@ strawberry.name = "MaxHelpingHand/SecretBerry"
 strawberry.depth = -100
 
 strawberry.texture = "collectables/moonBerry/normal00"
+function strawberry.rotation(room, entity)
+    return entity.rotation and (entity.rotation / 180 * math.pi) or 0
+end
 
 strawberry.placements = {
     name = "berry",
@@ -24,11 +27,22 @@ strawberry.placements = {
         particleColor2 = "FFF4A8",
         ghostParticleColor1 = "6385FF",
         ghostParticleColor2 = "72F0FF",
+        rotation = 0,
         visibleIfFlag = ""
     }
 }
 
-strawberry.fieldOrder = {"x", "y", "strawberrySprite", "ghostberrySprite", "strawberryPulseSound", "strawberryTouchSound", "strawberryBlueTouchSound", "strawberryGetSound", "particleColor1", "particleColor2", "ghostParticleColor1", "ghostParticleColor2"}
+strawberry.fieldOrder = {
+    "x", "y",
+    "strawberrySprite", "ghostberrySprite",
+    "strawberryPulseSound", "strawberryTouchSound",
+    "strawberryBlueTouchSound", "strawberryGetSound",
+    "particleColor1", "particleColor2",
+    "ghostParticleColor1", "ghostParticleColor2",
+    "checkpointID", "order",
+    "rotation", "visibleIfFlag",
+    "countTowardsTotal", "moonBerrySound", "pulseEnabled", "spotlightEnabled"
+}
 
 strawberry.fieldInformation = {
     particleColor1 = {
@@ -48,6 +62,9 @@ strawberry.fieldInformation = {
     },
     checkpointID = {
         fieldType = "integer"
+    },
+    rotation = {
+        default = 0
     }
 }
 

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -78,6 +78,7 @@ entities.MaxHelpingHand/CustomizableRefill.attributes.description.shatterParticl
 entities.MaxHelpingHand/CustomizableRefill.attributes.description.glowParticleColor1=One of the 2 colors of the particles the refill emits when glowing or respawning. If one of the colors is left empty, the refill will use vanilla particle colors.
 entities.MaxHelpingHand/CustomizableRefill.attributes.description.glowParticleColor2=One of the 2 colors of the particles the refill emits when glowing or respawning. If one of the colors is left empty, the refill will use vanilla particle colors.
 entities.MaxHelpingHand/CustomizableRefill.attributes.description.wave=Whether the refill should wave up and down, like vanilla refills. This is only visual, the hitbox does not move.
+entities.MaxHelpingHand/CustomizableRefill.attributes.description.rotation=The clockwise rotation angle of the refill, in degrees.
 
 # Custom Memorial (with Dreaming attribute)
 entities.MaxHelpingHand/CustomMemorialWithDreamingAttribute.placements.name.dreaming=Custom Memorial (Dreaming)
@@ -726,6 +727,7 @@ entities.MaxHelpingHand/SecretBerry.attributes.description.particleColor1=One of
 entities.MaxHelpingHand/SecretBerry.attributes.description.particleColor2=One of the colors to use for the particles the strawberry emits when not already collected.
 entities.MaxHelpingHand/SecretBerry.attributes.description.ghostParticleColor1=One of the colors to use for the particles the strawberry emits when already collected.
 entities.MaxHelpingHand/SecretBerry.attributes.description.ghostParticleColor2=One of the colors to use for the particles the strawberry emits when already collected.
+entities.MaxHelpingHand/SecretBerry.attributes.description.rotation=The clockwise rotation angle of the strawberry, in degrees.
 entities.MaxHelpingHand/SecretBerry.attributes.description.visibleIfFlag=If filled out, the strawberry will only be visible (and collectable) when the given flag is set.\nThis will stop having an effect when the berry is grabbed by the player.
 entities.MaxHelpingHand/SecretBerry.attributes.name.strawberryPulseSound=Pulse Sound
 entities.MaxHelpingHand/SecretBerry.attributes.name.strawberryBlueTouchSound=Collected Touch Sound
@@ -755,6 +757,7 @@ entities.MaxHelpingHand/CustomizableBerry.attributes.description.particleColor1=
 entities.MaxHelpingHand/CustomizableBerry.attributes.description.particleColor2=One of the colors to use for the particles the strawberry emits when not already collected.
 entities.MaxHelpingHand/CustomizableBerry.attributes.description.ghostParticleColor1=One of the colors to use for the particles the strawberry emits when already collected.
 entities.MaxHelpingHand/CustomizableBerry.attributes.description.ghostParticleColor2=One of the colors to use for the particles the strawberry emits when already collected.
+entities.MaxHelpingHand/CustomizableBerry.attributes.description.rotation=The clockwise rotation angle of the strawberry, in degrees.
 entities.MaxHelpingHand/CustomizableBerry.attributes.description.visibleIfFlag=If filled out, the strawberry will only be visible (and collectable) when the given flag is set.\nThis will stop having an effect when the berry is grabbed by the player.
 entities.MaxHelpingHand/CustomizableBerry.attributes.name.strawberryPulseSound=Pulse Sound
 entities.MaxHelpingHand/CustomizableBerry.attributes.name.strawberryBlueTouchSound=Collected Touch Sound
@@ -1178,6 +1181,7 @@ entities.MaxHelpingHand/ReskinnableCrystalHeart.attributes.description.particleC
 entities.MaxHelpingHand/ReskinnableCrystalHeart.attributes.description.flagOnCollect=The session flag to set when the heart is collected.\nLeave blank if you do not want any flag to be set.
 entities.MaxHelpingHand/ReskinnableCrystalHeart.attributes.description.flagInverted=If enabled, the flag specified in "Flag On Collect" will be disabled when the heart is collected, instead of being enabled.
 entities.MaxHelpingHand/ReskinnableCrystalHeart.attributes.description.disableGhostSprite=If this option is enabled, the heart will look the same no matter if it was already collected or not, and will never use its ghost sprite.
+entities.MaxHelpingHand/ReskinnableCrystalHeart.attributes.description.rotation=The clockwise rotation angle of the heart, in degrees.
 
 # Set Flag on Button Press Controller
 entities.MaxHelpingHand/SetFlagOnButtonPressController.placements.name.controller=Set Flag On Button Press Controller

--- a/Module/MaxHelpingHandModule.cs
+++ b/Module/MaxHelpingHandModule.cs
@@ -145,6 +145,7 @@ namespace Celeste.Mod.MaxHelpingHand.Module {
                 SpikeRefillController.Load();
                 SideSpecificEndscreens.Load();
                 Pico8FlagController.Load();
+                CustomizableRefill.Load();
 
                 Everest.Events.Level.OnLoadBackdrop += onLoadBackdrop;
 
@@ -242,6 +243,7 @@ namespace Celeste.Mod.MaxHelpingHand.Module {
             SideSpecificEndscreens.Unload();
             Pico8FlagController.Unload();
             SpeedrunToolInterop.Unload();
+            CustomizableRefill.Unload();
 
             Everest.Events.Level.OnLoadBackdrop -= onLoadBackdrop;
 


### PR DESCRIPTION
As the title describes, this PR allows mappers to rotate the following entities:
- `CustomizableBerry`
- `CustomizableRefill`
- `ReskinnableCrystalHeart`
- `SecretBerry`

Additionally, the PR makes the rotation immediately visible in Lönn, and organizes the fields of these entities in a better way if possible.
If Ahorn support is needed, please let me know so that I can implement it.