### PR TITLE
Color Grade Fade trigger improvements

### DIFF
--- a/Module/MaxHelpingHandModule.cs
+++ b/Module/MaxHelpingHandModule.cs
@@ -145,6 +145,7 @@ namespace Celeste.Mod.MaxHelpingHand.Module {
                 SpikeRefillController.Load();
                 SideSpecificEndscreens.Load();
                 Pico8FlagController.Load();
+                TriggerDuringReflectionFall.Load();
 
                 Everest.Events.Level.OnLoadBackdrop += onLoadBackdrop;
 
@@ -242,6 +243,7 @@ namespace Celeste.Mod.MaxHelpingHand.Module {
             SideSpecificEndscreens.Unload();
             Pico8FlagController.Unload();
             SpeedrunToolInterop.Unload();
+            TriggerDuringReflectionFall.Unload();
 
             Everest.Events.Level.OnLoadBackdrop -= onLoadBackdrop;
 

--- a/Triggers/ColorGradeFadeTrigger.cs
+++ b/Triggers/ColorGradeFadeTrigger.cs
@@ -36,7 +36,7 @@ namespace Celeste.Mod.MaxHelpingHand.Triggers {
         }
 
         private static bool modColorGradeUpdate(Level level) {
-            return level.Tracker.GetEntities<ColorGradeFadeTrigger>().Cast<ColorGradeFadeTrigger>().Any(t => t.PlayerIsInside);
+            return level.Tracker.GetEntities<ColorGradeFadeTrigger>().Cast<ColorGradeFadeTrigger>().Any(t => t.Triggered);
         }
 
         private string colorGradeA;

--- a/Triggers/ColorGradeFadeTrigger.cs
+++ b/Triggers/ColorGradeFadeTrigger.cs
@@ -1,79 +1,76 @@
-﻿using System.Collections.Generic;
-using Celeste.Mod.Entities;
+﻿using Celeste.Mod.Entities;
+using Celeste.Mod.Helpers;
 using Microsoft.Xna.Framework;
 using Monocle;
-using MonoMod.Utils;
 using System.Linq;
-using Celeste.Mod.MaxHelpingHand.Module;
+using MonoMod.Cil;
 
 namespace Celeste.Mod.MaxHelpingHand.Triggers {
     [CustomEntity("MaxHelpingHand/ColorGradeFadeTrigger")]
     [Tracked]
     public class ColorGradeFadeTrigger : Trigger {
         public static void Load() {
-            On.Celeste.Level.Update += onLevelUpdate;
+            IL.Celeste.Level.Update += modLevelUpdate;
         }
 
         public static void Unload() {
-            On.Celeste.Level.Update -= onLevelUpdate;
+            IL.Celeste.Level.Update -= modLevelUpdate;
         }
 
-        private static void onLevelUpdate(On.Celeste.Level.orig_Update orig, Level self) {
-            orig(self);
-
-            Player player = self.Tracker.GetEntity<Player>();
-
-            // if a Lucky Helper Dummy Player is inside a trigger, it takes priority over the actual player
-            foreach (Player dummyPlayer in LuckyHelperImports.GetDummyPlayers()) {
-                if (dummyPlayer.CollideCheck<ColorGradeFadeTrigger>()) {
-                    player = dummyPlayer;
-                    break;
-                }
-            }
-
-            // check if the player is in a color grade fade trigger
-            ColorGradeFadeTrigger trigger = self.Tracker.GetEntities<ColorGradeFadeTrigger>().OfType<ColorGradeFadeTrigger>()
-                .FirstOrDefault(t => t.evenDuringReflectionFall ? player?.Collider.Collide(t) ?? false : t.playerInside);
-            if (player != null && trigger != null) {
-                // the game fades from lastColorGrade to Session.ColorGrade using colorGradeEase as a lerp value.
-                // let's hijack that!
-                float positionLerp = trigger.GetPositionLerp(player, trigger.direction);
-                if (positionLerp > 0.5f) {
-                    // we are closer to B. let B be the target color grade when player exits the trigger / dies in it
-                    self.lastColorGrade = trigger.colorGradeA;
-                    self.Session.ColorGrade = trigger.colorGradeB;
-                    self.colorGradeEase = positionLerp;
-                } else {
-                    // we are closer to A. let A be the target color grade when player exits the trigger / dies in it
-                    self.lastColorGrade = trigger.colorGradeB;
-                    self.Session.ColorGrade = trigger.colorGradeA;
-                    self.colorGradeEase = 1 - positionLerp;
-                }
-                self.colorGradeEaseSpeed = 1f;
+        private static void modLevelUpdate(ILContext il) {
+            ILCursor cursor = new(il);
+            
+            ILLabel skipColorGradeUpdate = null;
+            if (cursor.TryGotoNextBestFit(MoveType.Before,
+                instr => instr.MatchLdarg0(),
+                instr => instr.MatchLdfld<Level>("lastColorGrade"),
+                instr => instr.MatchLdarg0(),
+                instr => instr.MatchLdfld<Level>("Session"),
+                instr => instr.MatchLdfld<Session>("ColorGrade"),
+                instr => instr.MatchCall<string>("op_Inequality"),
+                instr => instr.MatchBrfalse(out skipColorGradeUpdate))) {
+                cursor.EmitLdarg0();
+                cursor.EmitDelegate(modColorGradeUpdate);
+                cursor.EmitBrtrue(skipColorGradeUpdate!);
             }
         }
 
+        private static bool modColorGradeUpdate(Level level) {
+            return level.Tracker.GetEntities<ColorGradeFadeTrigger>().Cast<ColorGradeFadeTrigger>().Any(t => t.PlayerIsInside);
+        }
 
         private string colorGradeA;
         private string colorGradeB;
         private PositionModes direction;
         private bool evenDuringReflectionFall;
 
-        private bool playerInside = false;
-
         public ColorGradeFadeTrigger(EntityData data, Vector2 offset) : base(data, offset) {
             colorGradeA = data.Attr("colorGradeA");
             colorGradeB = data.Attr("colorGradeB");
             direction = data.Enum<PositionModes>("direction");
             evenDuringReflectionFall = data.Bool("evenDuringReflectionFall", true); // true by default for backwards compatibility
+
+            if (evenDuringReflectionFall) {
+                Add(new TriggerDuringReflectionFall());
+            }
         }
 
-        public override void OnEnter(Player player) {
-            playerInside = true;
-        }
-
-        public override void OnLeave(Player player) {
-            playerInside = false;
+        public override void OnStay(Player player) {
+            Level level = SceneAs<Level>();
+            
+            float positionLerp = GetPositionLerp(player, direction);
+            if (positionLerp > 0.5f) {
+                // we are closer to B. let B be the target color grade when player exits the trigger / dies in it
+                level.lastColorGrade = colorGradeA;
+                level.Session.ColorGrade = colorGradeB;
+                level.colorGradeEase = positionLerp;
+            } else {
+                // we are closer to A. let A be the target color grade when player exits the trigger / dies in it
+                level.lastColorGrade = colorGradeB;
+                level.Session.ColorGrade = colorGradeA;
+                level.colorGradeEase = 1 - positionLerp;
+            }
+            level.colorGradeEaseSpeed = 1f;
         }
     }
 }

--- a/Triggers/TriggerDuringReflectionFall.cs
+++ b/Triggers/TriggerDuringReflectionFall.cs
@@ -27,7 +27,7 @@ namespace Celeste.Mod.MaxHelpingHand.Triggers {
                 instr => instr.MatchLdarg0(),
                 instr => instr.MatchLdfld<Player>("StateMachine"),
                 instr => instr.MatchCallvirt<StateMachine>("get_State"),
-                instr => instr.MatchLdcI4(18),
+                instr => instr.MatchLdcI4(Player.StReflectionFall),
                 instr => instr.MatchBeq(out _))) {
                 ILLabel skipStateCheck = cursor.DefineLabel();
                 

--- a/Triggers/TriggerDuringReflectionFall.cs
+++ b/Triggers/TriggerDuringReflectionFall.cs
@@ -12,7 +12,7 @@ namespace Celeste.Mod.MaxHelpingHand.Triggers {
         private static ILHook hookModPlayerOrigUpdate;
         
         public static void Load() {
-            hookModPlayerOrigUpdate = new ILHook(typeof(Player).GetMethod("orig_Update", BindingFlags.NonPublic | BindingFlags.Instance)!, modPlayerOrigUpdate);
+            hookModPlayerOrigUpdate = new ILHook(typeof(Player).GetMethod("orig_Update", BindingFlags.Public | BindingFlags.Instance)!, modPlayerOrigUpdate);
         }
 
         public static void Unload() {

--- a/Triggers/TriggerDuringReflectionFall.cs
+++ b/Triggers/TriggerDuringReflectionFall.cs
@@ -24,19 +24,10 @@ namespace Celeste.Mod.MaxHelpingHand.Triggers {
             ILCursor cursor = new(il);
 
             if (cursor.TryGotoNextBestFit(MoveType.Before,
-                instr => instr.MatchLdarg0(),
-                instr => instr.MatchLdfld<Player>("StateMachine"),
-                instr => instr.MatchCallvirt<StateMachine>("get_State"),
                 instr => instr.MatchLdcI4(Player.StReflectionFall),
                 instr => instr.MatchBeq(out _))) {
-                ILLabel skipStateCheck = cursor.DefineLabel();
-                
                 cursor.EmitLdarg0();
                 cursor.EmitDelegate(modStateCheck);
-                cursor.EmitBrtrue(skipStateCheck);
-                
-                cursor.GotoNext(MoveType.After, instr => instr.MatchBeq(out _));
-                cursor.MarkLabel(skipStateCheck);
             }
             
             ILLabel loopStart = null;
@@ -53,8 +44,8 @@ namespace Celeste.Mod.MaxHelpingHand.Triggers {
             }
         }
 
-        private static bool modStateCheck(Player player) {
-            return player.Scene.Tracker.GetComponent<TriggerDuringReflectionFall>() != null;
+        private static int modStateCheck(int origState, Player player) {
+            return player.Scene.Tracker.GetComponent<TriggerDuringReflectionFall>() == null ? origState : -1;
         }
         
         private static bool modSkipTrigger(Player player, Trigger trigger) {

--- a/Triggers/TriggerDuringReflectionFall.cs
+++ b/Triggers/TriggerDuringReflectionFall.cs
@@ -1,0 +1,72 @@
+using Celeste.Mod.Helpers;
+using Monocle;
+using MonoMod.Cil;
+using MonoMod.RuntimeDetour;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Celeste.Mod.MaxHelpingHand.Triggers {
+    [Tracked]
+    public class TriggerDuringReflectionFall() : Component(false, false) {
+        private static ILHook hookModPlayerOrigUpdate;
+        
+        public static void Load() {
+            hookModPlayerOrigUpdate = new ILHook(typeof(Player).GetMethod("orig_Update", BindingFlags.NonPublic | BindingFlags.Instance)!, modPlayerOrigUpdate);
+        }
+
+        public static void Unload() {
+            hookModPlayerOrigUpdate?.Dispose();
+            hookModPlayerOrigUpdate = null;
+        }
+
+        private static void modPlayerOrigUpdate(ILContext il) {
+            ILCursor cursor = new(il);
+
+            if (cursor.TryGotoNextBestFit(MoveType.Before,
+                instr => instr.MatchLdarg0(),
+                instr => instr.MatchLdfld<Player>("StateMachine"),
+                instr => instr.MatchCallvirt<StateMachine>("get_State"),
+                instr => instr.MatchLdcI4(18),
+                instr => instr.MatchBeq(out _))) {
+                ILLabel skipStateCheck = cursor.DefineLabel();
+                
+                cursor.EmitLdarg0();
+                cursor.EmitDelegate(modStateCheck);
+                cursor.EmitBrtrue(skipStateCheck);
+                
+                cursor.GotoNext(MoveType.After, instr => instr.MatchBeq(out _));
+                cursor.MarkLabel(skipStateCheck);
+            }
+            
+            ILLabel loopStart = null;
+            if (cursor.TryGotoNextBestFit(MoveType.After,
+                instr => instr.MatchBr(out loopStart),
+                instr => instr.MatchLdloca(9),
+                instr => instr.MatchCall<List<Entity>.Enumerator>("get_Current"),
+                instr => instr.MatchCastclass<Trigger>(),
+                instr => instr.MatchStloc(10))) {
+                cursor.EmitLdarg0();
+                cursor.EmitLdloc(10);
+                cursor.EmitDelegate(modSkipTrigger);
+                cursor.EmitBrtrue(loopStart!);
+            }
+        }
+
+        private static bool modStateCheck(Player player) {
+            return player.Scene.Tracker.GetComponent<TriggerDuringReflectionFall>() != null;
+        }
+        
+        private static bool modSkipTrigger(Player player, Trigger trigger) {
+            return player.StateMachine.State == Player.StReflectionFall && trigger.Get<TriggerDuringReflectionFall>() == null;
+        }
+
+        public override void Added(Entity entity) {
+            if (entity is not Trigger) {
+                throw new InvalidOperationException("Cannot add a TriggerDuringReflectionFall component to something that is not a Trigger!");
+            }
+
+            base.Added(entity);
+        }
+    }
+}


### PR DESCRIPTION
Previously, since the color grade updating logic was not done directly in `OnEnter`/`OnStay`/`OnLeave`, these triggers did not work correctly with Timed Fade Triggers from Crystalline when the Even During Reflection Fall option was checked. This PR fixes this by doing the changing the color grade in `OnStay` and skipping the `Level.Update` logic if necessary. Since this way of doing things no longer admits a "clean" way to work during reflection fall state, this PR also adds a component that will make any trigger work during reflection fall state.